### PR TITLE
fix ephemeral bool

### DIFF
--- a/tasks/deploy.yml
+++ b/tasks/deploy.yml
@@ -7,7 +7,7 @@
         --param=GOGS_VERSION={{ gogs_image_version }} \
         --param=SKIP_TLS_VERIFY=true \
         -n {{ project_name }}
-  when: not ephemeral
+  when: not ephemeral|bool
 
 - name: deploy gogs from template (ephemeral)
   shell: |
@@ -16,7 +16,7 @@
         --param=GOGS_VERSION={{ gogs_image_version }} \
         --param=SKIP_TLS_VERIFY=true \
         -n {{ project_name }}
-  when: ephemeral
+  when: ephemeral|bool
 
 - name: wait for gogs postgresql to be running
   uri:


### PR DESCRIPTION
I used `-e ephemeral=false` and got the following, both skipping:

```
TASK [/tmp/shared-msac-demo-77fd/ansible_agnostic_deployer/ansible/roles/openshift_gogs : deploy gogs from template (persistent)] ***
Wednesday 21 February 2018  04:15:22 -0500 (0:00:01.094)       0:00:58.780 **** 
skipping: [bastion.rhpds.openshift.opentlc.com]

TASK [/tmp/shared-msac-demo-77fd/ansible_agnostic_deployer/ansible/roles/openshift_gogs : deploy gogs from template (ephemeral)] ***
Wednesday 21 February 2018  04:15:22 -0500 (0:00:00.024)       0:00:58.804 **** 
skipping: [bastion.rhpds.openshift.opentlc.com]
```